### PR TITLE
fix: tag repetition on some CamelCase difference

### DIFF
--- a/src/data/tags.js
+++ b/src/data/tags.js
@@ -2,8 +2,8 @@ import data from "./data";
 
 const tags = data.reduce((acc, item) => {
   item.tags.forEach((tag) => {
-    if (!acc.includes(tag)) {
-      acc.push(tag);
+    if (!acc.map(a => a.toLowerCase()).includes(tag.toLowerCase())) {
+      acc.push(tag.toLowerCase());
     }
   });
   return acc;


### PR DESCRIPTION
## WHAT

fix: tag repetition on some CamelCase difference
There should not be a difference between "BackEnd" and "Backend" or "backEnD"

## ADDITIONAL INFOS
### BEFORE
![Screenshot from 2022-06-26 04-01-13](https://user-images.githubusercontent.com/22576758/175796236-62827e50-3ca3-4a7a-a185-d7c1e5e9e0d6.png)

---
---
### AFTER
![Screenshot from 2022-06-26 04-00-51](https://user-images.githubusercontent.com/22576758/175796234-337541f3-a1f8-4a5c-a911-faed3db8ae09.png)